### PR TITLE
Local file playlist fix

### DIFF
--- a/exportify.js
+++ b/exportify.js
@@ -280,7 +280,7 @@ let PlaylistExporter = {
 			});
 			// add features
 			features = features.flat();
-			data.forEach((row, i) => features[i].forEach(feat => row.push(feat)));
+			data.forEach((row, i) => features[i]?.forEach(feat => row.push(feat)));
 			// add titles
 			data.unshift(["Spotify ID", "Artist IDs", "Track Name", "Album Name", "Artist Name(s)", "Release Date",
 				"Duration (ms)", "Popularity", "Added By", "Added At", "Genres", "Danceability", "Energy", "Key", "Loudness",


### PR DESCRIPTION
Playlists with a local file as the last song entry present a Type Error due to null fields being iterated on line 283.  This null type error was caught on line 206. Adding a  ? to the feature variable on line 283 will ignore these null entries and successfully add the data that is present into the final CSV.

Resolves issue #28